### PR TITLE
fix for path.join error on null filename

### DIFF
--- a/lib/watch.js
+++ b/lib/watch.js
@@ -219,7 +219,9 @@ function watch(fpath, options, cb) {
     }).on('error', catchException);                         
   } else if (is.dir(fpath)) {
     fs.watch(fpath, function(evt, fname) {
-      normalizeCall(path.join(fpath, fname), options, cb);
+      if (fname) {
+        normalizeCall(path.join(fpath, fname), options, cb);
+      }
     }).on('error', catchException);
 
     if (options.recursive) {


### PR DESCRIPTION
When deleting files from a watched dir in Windows it seems the watch callback is triggered with a null filename.
