### PR TITLE
add filter function in the watch process

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ This module **currently** does not differentiate event like `rename` or `delete`
 
 `maxSymLevel`: The max number of following symbolic links, in order to prevent circular links (defaults to **1**). 
 
+`filter`: node-watch will only watch elements that pass the test implemented by the provided function. The filter function is provided with a full path string argument(defaults to ```(fullPath)=>true``` ). 
+
 
 ```js
 watch('somedir', { recursive: false, followSymLinks: true }, function(filename) {
@@ -56,7 +58,7 @@ watch(['file1', 'file2'], function(file) {
 
 #### 2. How to filter files
 
-Write your own filter function as a higher-order function. For example:
+You can write your own filter function as a higher-order function. For example:
 
 ```js
 var filter = function(pattern, fn) {
@@ -66,9 +68,22 @@ var filter = function(pattern, fn) {
     }
   }
 }
-
 // only watch for js files
 watch('mydir', filter(/\.js$/, function(filename) {
   // 
 }));
 ```
+
+Alternatively, supply a filter function in the options object. For example:
+```js
+// don't watch node_modules folder
+var options = {
+  filter : function(filename) {
+    return /node_modules/.test(filename);
+  }
+};
+watch('mydir', options, function(filename) {
+  // 
+}));
+```
+The second approach helps avoiding the [max open files](http://stackoverflow.com/questions/3734932/max-open-files-for-working-process) limit

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Alternatively, supply a filter function in the options object. For example:
 // don't watch node_modules folder
 var options = {
   filter : function(filename) {
-    return /node_modules/.test(filename);
+    return !/node_modules/.test(filename);
   }
 };
 watch('mydir', options, function(filename) {

--- a/lib/watch.js
+++ b/lib/watch.js
@@ -36,7 +36,7 @@ var sub = function(parent, cb) {
   if (is.dir(parent)) {
     fs.readdir(parent, function(err, all) {
       all && all.forEach(function(f) {
-        var sdir = path.join(parent, f) 
+        var sdir = path.join(parent, f);
         if (is.dir(sdir)) {
           cb.call(null, sdir) 
         }
@@ -194,7 +194,7 @@ var handleOptions = function(origin, defaultOptions) {
  *   `recursive`:      Watch it recursively or not (defaults to true).
  *   `followSymLinks`: Follow symbolic links or not (defaults to false).
  *   `maxSymLevel`:    The max number of following symbolic links (defaults to 1). 
- *
+ *   `filter`:         Filter function(fullPath:string)=>boolean (defaults to ()=>true )
  * Example: 
  *
  *   watch('fpath', {recursive: true}, function(file) {
@@ -207,31 +207,33 @@ function watch(fpath, options, cb) {
       && options.maxSymLevel--)) {
     return;
   }
-  // Due to the unstable fs.watch(), if the `fpath` is a file then 
-  // switch to watch its parent directory instead of watch it directly. 
-  // Once the logged filename matches it then triggers the callback function.
-  if (is.file(fpath)) {
-    var parent = path.resolve(fpath, '..');
-    fs.watch(parent, options, function(evt, fname) {
-      if (path.basename(fpath) === fname) {
-        normalizeCall(fpath, options, cb);
-      }
-    }).on('error', catchException);                         
-  } else if (is.dir(fpath)) {
-    fs.watch(fpath, options, function(evt, fname) {
-      if (fname) {
-        normalizeCall(path.join(fpath, fname), options, cb);
-      }
-    }).on('error', catchException);
+  if (options.filter(fpath)) {
+    // Due to the unstable fs.watch(), if the `fpath` is a file then
+    // switch to watch its parent directory instead of watch it directly.
+    // Once the logged filename matches it then triggers the callback function.
+    if (is.file(fpath)) {
+      var parent = path.resolve(fpath, '..');
+      fs.watch(parent, options, function (evt, fname) {
+        if (path.basename(fpath) === fname) {
+          normalizeCall(fpath, options, cb);
+        }
+      }).on('error', catchException);
+    } else if (is.dir(fpath)) {
+      fs.watch(fpath, options, function (evt, fname) {
+        if (fname) {
+          normalizeCall(path.join(fpath, fname), options, cb);
+        }
+      }).on('error', catchException);
 
-    if (options.recursive) {
-      // Recursively watch its sub-directories. 
-      sub(fpath, function(dir) {
-        watch(dir, options, cb);
-      });    
+      if (options.recursive) {
+        // Recursively watch its sub-directories.
+        sub(fpath, function (dir) {
+          watch(dir, options, cb);
+        });
+      }
     }
   }
-}; 
+}
 
 
 /**
@@ -241,5 +243,6 @@ module.exports = handleOptions(watch, {
     recursive: true
   , followSymLinks: false
   , maxSymLevel: 1
+  , filter: function(fullPath){return true;}
 });
 

--- a/lib/watch.js
+++ b/lib/watch.js
@@ -202,35 +202,33 @@ var handleOptions = function(origin, defaultOptions) {
  *   });
  */
 function watch(fpath, options, cb) {
-  if (is.sym(fpath) 
+  if (!options.filter(fpath) || ((is.sym(fpath)
     && !(options.followSymLinks 
-      && options.maxSymLevel--)) {
+      && options.maxSymLevel--)))) {
     return;
   }
-  if (options.filter(fpath)) {
-    // Due to the unstable fs.watch(), if the `fpath` is a file then
-    // switch to watch its parent directory instead of watch it directly.
-    // Once the logged filename matches it then triggers the callback function.
-    if (is.file(fpath)) {
-      var parent = path.resolve(fpath, '..');
-      fs.watch(parent, options, function (evt, fname) {
-        if (path.basename(fpath) === fname) {
-          normalizeCall(fpath, options, cb);
-        }
-      }).on('error', catchException);
-    } else if (is.dir(fpath)) {
-      fs.watch(fpath, options, function (evt, fname) {
-        if (fname) {
-          normalizeCall(path.join(fpath, fname), options, cb);
-        }
-      }).on('error', catchException);
-
-      if (options.recursive) {
-        // Recursively watch its sub-directories.
-        sub(fpath, function (dir) {
-          watch(dir, options, cb);
-        });
+  // Due to the unstable fs.watch(), if the `fpath` is a file then
+  // switch to watch its parent directory instead of watch it directly.
+  // Once the logged filename matches it then triggers the callback function.
+  if (is.file(fpath)) {
+    var parent = path.resolve(fpath, '..');
+    fs.watch(parent, options, function(evt, fname) {
+      if (path.basename(fpath) === fname) {
+        normalizeCall(fpath, options, cb);
       }
+    }).on('error', catchException);
+  } else if (is.dir(fpath)) {
+    fs.watch(fpath, options, function(evt, fname) {
+      if (fname) {
+        normalizeCall(path.join(fpath, fname), options, cb);
+      }
+    }).on('error', catchException);
+
+    if (options.recursive) {
+      // Recursively watch its sub-directories.
+      sub(fpath, function(dir) {
+        watch(dir, options, cb);
+      });
     }
   }
 }


### PR DESCRIPTION
helps avoid file table overflow in OSX when you only want to watch a subset of a folder's content