### PR TITLE
Do not close Watcher when there are still subdirs remaining

### DIFF
--- a/lib/is.js
+++ b/lib/is.js
@@ -13,6 +13,12 @@ var is = {
   array: function(item) {
     return Array.isArray(item);
   },
+  emptyObject: function(item) {
+    for (var key in item) {
+      return false;
+    }
+    return true;
+  },
   buffer: function(item) {
     return Buffer.isBuffer(item);
   },

--- a/lib/watch.js
+++ b/lib/watch.js
@@ -204,8 +204,12 @@ Watcher.prototype.close = function(fullPath) {
     });
     this.watchers = {};
   }
-  this._isClosed = true;
-  process.nextTick(emitClose, this);
+  // Do not close the Watcher unless all child watchers are closed.
+  // https://github.com/yuanchuan/node-watch/issues/75
+  if (is.emptyObject(self.watchers)) {
+    this._isClosed = true;
+    process.nextTick(emitClose, this);
+  }
 };
 
 function emitReady(self) {

--- a/test/test.js
+++ b/test/test.js
@@ -135,6 +135,29 @@ describe('watch for directories', function() {
       tree.modify('home/new/file1', 100);
     });
   });
+
+  it('should keep watching after removal of sub directory', function(done) {
+    var home = tree.getPath('home');
+    var file1 = tree.getPath('home/e/file1');
+    var file2 = tree.getPath('home/e/file2');
+    var dir = tree.getPath('home/e/sub');
+    var events = [];
+    watcher = watch(home, { delay: 0, recursive: true }, function(evt, name) {
+      if (name === dir || name === file1 || name === file2) {
+        events.push(name);
+      }
+    });
+    watcher.on('ready', function() {
+      tree.remove('home/e/sub', 50);
+      tree.modify('home/e/file1', 100);
+      tree.modify('home/e/file2', 200);
+
+      setTimeout(function() {
+        assert.deepStrictEqual(events, [dir, file1, file2]);
+        done();
+      }, 300);
+    });
+  });
 });
 
 describe('file events', function() {
@@ -318,8 +341,8 @@ describe('options', function() {
         tree.modify(file2);
 
         setTimeout(function() {
-          assert(times, 1, 'report file2');
-          assert(!matchIgnoredFile, 'home/bb/file1 should be ignored');
+          assert.equal(times, 1, 'report file2');
+          assert.equal(matchIgnoredFile, false, 'home/bb/file1 should be ignored');
           done();
         }, 100);
       });

--- a/test/utils/structure
+++ b/test/utils/structure
@@ -12,6 +12,10 @@ home/
   d/
     file1
     file2
+  e/
+    file1
+    file2
+    sub/
   deep_node_modules/
     ma/
       file1


### PR DESCRIPTION
The callback in Watcher#add calls close() on every kind of
removal, including removals of regular files and  sub directories.

The rest of this function accounts for that correctly, by using
the fullPath to find the associated child watcher, and only
closing that specific one. (And doing nothing, if there is no
matching child watcher, e.g. if it was just a regular file being
removed.)

However, the last lines of the function still unconditionally
closed the main Watcher, which means events would still come
through to the internal debounced callback, but then caught
by the self.isClosed() check and not reported to the user.

Fixes #75.