### PR TITLE
Add an extra flag for skipping sub-directories inside filter function.

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,9 +68,8 @@ The usage and options of `node-watch` are compatible with [fs.watch](https://nod
      * **`false`**: Will not be passed to callback.
      * **`skip`**: Same with `false`, and skip to watch all its subdirectories.
 
-
    On Linux, where the `recursive` option is not natively supported,
-   you could skip to watch all its subdirectories by returning the `skip` flag.
+   it is more efficient to skip ignored directories by returning the `skip` flag:
 
     ```js
     watch('./', {
@@ -87,15 +86,16 @@ The usage and options of `node-watch` are compatible with [fs.watch](https://nod
 
     ```
 
-    Use [minimatch](https://www.npmjs.com/package/minimatch) for filter:
+    If you prefer glob patterns you can use [minimatch](https://www.npmjs.com/package/minimatch) or [picomatch](https://www.npmjs.com/package/picomatch)
+    together with filter:
 
      ```js
-     let minimatch = require("minimatch");
+     const pm = require('picomatch');
+     let isMatch = pm('*.js');
 
      watch('./', {
-       filter: f => minimatch(f, "*.js")
+       filter: f => isMatch(f)
      });
-
      ```
 
 * `delay: Number` (in ms, default **200**)

--- a/lib/is.js
+++ b/lib/is.js
@@ -72,6 +72,9 @@ var is = {
   },
   windows: function() {
     return os.platform() === 'win32';
+  },
+  skipFlag: function(value) {
+    return /^\s*skip\s*$/i.test(value);
   }
 };
 

--- a/lib/is.js
+++ b/lib/is.js
@@ -72,9 +72,6 @@ var is = {
   },
   windows: function() {
     return os.platform() === 'win32';
-  },
-  skipFlag: function(value) {
-    return /^\s*skip\s*$/i.test(value);
   }
 };
 

--- a/lib/watch.d.ts
+++ b/lib/watch.d.ts
@@ -1,63 +1,75 @@
 import { FSWatcher } from 'fs';
 
 /**
- * Watch for changes on `filename`, where filename is either a file or a directory. The second argument is optional.
+ *  Watch for changes on `filename`, where filename is either a file or a directory.
+ *  The second argument is optional.
  *
- * - If `options` is provided as a string, it specifies the encoding. Otherwise `options` should be passed as an object.
+ *  If `options` is provided as a string, it specifies the encoding.
+ *  Otherwise `options` should be passed as an object.
  *
- * - The listener callback gets two arguments `(eventType, filename)`. `eventType` is either `update` or `remove`, and
- * `filename` is the name of the file which triggered the event.
+ *  The listener callback gets two arguments, `(eventType, filePath)`,
+ *  which is the same with `fs.watch`.
+ *  `eventType` is either `update` or `remove`,
+ *  `filePath` is the name of the file which triggered the event.
  *
  * @param {Filename} filename File or directory to watch.
- * @param {WatchOptions|string} options
- * @param {Function} listener
+ * @param {Options|string} options
+ * @param {Function} callback
  */
-declare function watch(filename: Filename, listener : (eventType: 'update' | 'remove', filename: string) => any) : ImprovedFSWatcher;
-declare function watch(filename: Filename, options : string, listener : (eventType: 'update' | 'remove', filename: string) => any) : ImprovedFSWatcher;
-declare function watch(filename: Filename, options : WatchOptions, listener : (eventType: 'update' | 'remove', filename: string) => any) : ImprovedFSWatcher;
+declare function watch(pathName: PathName): Watcher;
+declare function watch(pathName: PathName, options: Options) : Watcher;
+declare function watch(pathName: PathName, callback: Callback): Watcher;
+declare function watch(pathName: PathName, options: Options, callback: Callback): Watcher;
 
-interface FilenameArray extends Array<FilenameArray | string> {}
+type EventType = 'update' | 'remove';
+type Callback = (eventType ?: EventType, filePath ?: string) => any;
+type PathName = string | Array<string>;
+type FilterReturn = boolean | symbol;
 
-type Filename = string | FilenameArray;
+type Options = {
+  /**
+   * Indicates whether the process should continue to run
+   * as long as files are being watched.
+   * @default true
+   */
+  persistent ?: boolean;
 
-type WatchOptions = {
-    /**
-     * Indicates whether the process should continue to run as long as files are being watched.
-     * @default true
-     */
-    persistent ?: boolean;
+  /**
+   * Indicates whether all subdirectories should be watched.
+   * @default false
+   */
+  recursive ?: boolean;
 
-    /**
-     * Indicates whether all subdirectories should be watched, or only the current directory. This applies when a
-     * directory is specified, and only on supported platforms.
-     *
-     * @default false
-     */
-    recursive ?: boolean;
+  /**
+   * Specifies the character encoding to be used for the filename
+   * passed to the listener.
+   * @default 'utf8'
+   */
+  encoding ?: string;
 
-    /**
-     * Specifies the character encoding to be used for the filename passed to the listener.
-     * @default 'utf8'
-     */
-    encoding ?: string;
+  /**
+   * Only files which pass this filter (when it returns `true`)
+   * will be sent to the listener.
+   */
+  filter ?: RegExp | ((file: string, skip: symbol) => FilterReturn);
 
-    /**
-     * Only files which pass this filter (when it returns `true`) will be sent to the listener.
-     */
-    filter ?: RegExp | ((file: string) => boolean);
-
-    /**
-     * Delay time of the callback function.
-     * @default 200
-     */
-    delay ?: number;
+  /**
+   * Delay time of the callback function.
+   * @default 200
+   */
+  delay ?: number;
 };
 
-declare interface ImprovedFSWatcher extends FSWatcher {
-    /**
-     * Returns `true` if the watcher has been closed.
-     */
-    isClosed(): boolean;
+declare interface Watcher extends FSWatcher {
+  /**
+   * Returns `true` if the watcher has been closed.
+   */
+  isClosed(): boolean;
+
+  /**
+   * Returns all watched paths.
+   */
+  getWatchedPaths(): Array<string>;
 }
 
 export default watch;

--- a/lib/watch.js
+++ b/lib/watch.js
@@ -32,7 +32,7 @@ function assertEncoding(encoding) {
 function guard(fn) {
   return function(arg, action) {
     if (is.func(fn)) {
-      let ret = fn(arg, SKIP_FLAG);
+      var ret = fn(arg, SKIP_FLAG);
       if (ret && ret !== SKIP_FLAG) action();
     }
     else if (is.regExp(fn)) {
@@ -195,12 +195,24 @@ util.inherits(Watcher, events.EventEmitter);
 Watcher.prototype.expose = function() {
   var self = this;
   var methods = [
-    'on', 'emit', 'close', 'isClosed', 'listeners', 'once',
-    'setMaxListeners', 'getMaxListeners'
+    'on', 'emit', 'once',
+    'close', 'isClosed',
+    'listeners', 'setMaxListeners', 'getMaxListeners',
+    'getWatchedPaths'
   ];
   return methods.reduce(function(expose, name) {
     expose[name] = function() {
-      return self[name].apply(self, arguments);
+      switch (name) {
+        case 'getWatchedPaths':
+          var fn = arguments[0];
+          return self.on('ready', function() {
+            if (is.func(fn)) {
+              fn(Object.keys(self.watchers));
+            }
+          });
+        default:
+          return self[name].apply(self, arguments);
+      }
     }
     return expose;
   }, {});

--- a/lib/watch.js
+++ b/lib/watch.js
@@ -193,29 +193,24 @@ function Watcher() {
 util.inherits(Watcher, events.EventEmitter);
 
 Watcher.prototype.expose = function() {
+  var expose = {};
   var self = this;
   var methods = [
     'on', 'emit', 'once',
     'close', 'isClosed',
     'listeners', 'setMaxListeners', 'getMaxListeners',
-    'getWatchedPaths'
   ];
-  return methods.reduce(function(expose, name) {
+  methods.forEach(name => {
     expose[name] = function() {
-      switch (name) {
-        case 'getWatchedPaths':
-          var fn = arguments[0];
-          return self.on('ready', function() {
-            if (is.func(fn)) {
-              fn(Object.keys(self.watchers));
-            }
-          });
-        default:
-          return self[name].apply(self, arguments);
-      }
+      return self[name].apply(self, arguments);
     }
-    return expose;
-  }, {});
+  });
+  expose.getWatchedPaths = function(fn) {
+    if (is.func(fn)) {
+      fn(Object.keys(self.watchers));
+    }
+  }
+  return expose;
 }
 
 Watcher.prototype.isClosed = function() {

--- a/lib/watch.js
+++ b/lib/watch.js
@@ -9,7 +9,7 @@ var is = require('./is');
 var EVENT_UPDATE = 'update';
 var EVENT_REMOVE = 'remove';
 
-var SKIP_FLAG = 'skip';
+var SKIP_FLAG = Symbol('skip');
 
 function hasDup(arr) {
   return arr.some(function(v, i, self) {

--- a/lib/watch.js
+++ b/lib/watch.js
@@ -30,7 +30,8 @@ function assertEncoding(encoding) {
 function guard(fn) {
   return function(arg, action) {
     if (is.func(fn)) {
-      if (fn(arg)) action();
+      let ret = fn(arg);
+      if (ret && !is.skipFlag(ret)) action();
     }
     else if (is.regExp(fn)) {
       if (fn.test(arg)) action();
@@ -381,7 +382,13 @@ Watcher.prototype.watchDirectory = function(dir, options, fn, counter = nullCoun
 
     if (options.recursive && !has) {
       getSubDirectories(dir, function(d) {
-        self.watchDirectory(d, options, null, counter);
+        if (is.func(options.filter)) {
+          if (!is.skipFlag(options.filter(d))) {
+            self.watchDirectory(d, options, null, counter);
+          }
+        } else {
+          self.watchDirectory(d, options, null, counter);
+        }
       }, counter());
     }
 

--- a/lib/watch.js
+++ b/lib/watch.js
@@ -32,7 +32,7 @@ function assertEncoding(encoding) {
 function guard(fn) {
   return function(arg, action) {
     if (is.func(fn)) {
-      let ret = fn(arg);
+      let ret = fn(arg, SKIP_FLAG);
       if (ret && ret !== SKIP_FLAG) action();
     }
     else if (is.regExp(fn)) {

--- a/lib/watch.js
+++ b/lib/watch.js
@@ -9,6 +9,8 @@ var is = require('./is');
 var EVENT_UPDATE = 'update';
 var EVENT_REMOVE = 'remove';
 
+var SKIP_FLAG = 'skip';
+
 function hasDup(arr) {
   return arr.some(function(v, i, self) {
     return self.indexOf(v) !== i;
@@ -31,7 +33,7 @@ function guard(fn) {
   return function(arg, action) {
     if (is.func(fn)) {
       let ret = fn(arg);
-      if (ret && !is.skipFlag(ret)) action();
+      if (ret && ret !== SKIP_FLAG) action();
     }
     else if (is.regExp(fn)) {
       if (fn.test(arg)) action();
@@ -383,7 +385,8 @@ Watcher.prototype.watchDirectory = function(dir, options, fn, counter = nullCoun
     if (options.recursive && !has) {
       getSubDirectories(dir, function(d) {
         if (is.func(options.filter)) {
-          if (!is.skipFlag(options.filter(d))) {
+          // Check to see whether to skip this directory.
+          if (options.filter(d, SKIP_FLAG) !== SKIP_FLAG) {
             self.watchDirectory(d, options, null, counter);
           }
         } else {

--- a/lib/watch.js
+++ b/lib/watch.js
@@ -200,7 +200,7 @@ Watcher.prototype.expose = function() {
     'close', 'isClosed',
     'listeners', 'setMaxListeners', 'getMaxListeners',
   ];
-  methods.forEach(name => {
+  methods.forEach(function(name) {
     expose[name] = function() {
       return self[name].apply(self, arguments);
     }

--- a/lib/watch.js
+++ b/lib/watch.js
@@ -199,17 +199,13 @@ Watcher.prototype.expose = function() {
     'on', 'emit', 'once',
     'close', 'isClosed',
     'listeners', 'setMaxListeners', 'getMaxListeners',
+    'getWatchedPaths'
   ];
   methods.forEach(function(name) {
     expose[name] = function() {
       return self[name].apply(self, arguments);
     }
   });
-  expose.getWatchedPaths = function(fn) {
-    if (is.func(fn)) {
-      fn(Object.keys(self.watchers));
-    }
-  }
   return expose;
 }
 
@@ -244,7 +240,17 @@ Watcher.prototype.close = function(fullPath) {
     this._isClosed = true;
     process.nextTick(emitClose, this);
   }
-};
+}
+
+Watcher.prototype.getWatchedPaths = function(fn) {
+  if (is.func(fn)) {
+    var self = this;
+    self.on('ready', function() {
+      var paths = Object.keys(self.watchers);
+      fn(paths);
+    });
+  }
+}
 
 function emitReady(self) {
   if (!self._isReady) {

--- a/lib/watch.js
+++ b/lib/watch.js
@@ -183,6 +183,12 @@ function nullCounter() {
   return function nullStop() {};
 }
 
+function shouldNotSkip(filePath, filter) {
+  // watch it only if the filter is not function
+  // or not being skipped explicitly.
+  return !is.func(filter) || filter(filePath, SKIP_FLAG) !== SKIP_FLAG;
+}
+
 var deprecationWarning = util.deprecate(
   function() {},
   '(node-watch) First param in callback function\
@@ -305,8 +311,14 @@ Watcher.prototype.add = function(watcher, info) {
             self.close(fullPath);
           }
           // watch new created directory
-          else if (is.directory(name) && !self.watchers[fullPath]) {
-            self.watchDirectory(name, info.options);
+          else {
+            var shouldWatch = is.directory(name)
+              && !self.watchers[fullPath]
+              && shouldNotSkip(name, info.options.filter);
+
+            if (shouldWatch) {
+              self.watchDirectory(name, info.options);
+            }
           }
         }
       });
@@ -407,9 +419,7 @@ Watcher.prototype.watchDirectory = function(dir, options, fn, counter = nullCoun
 
     if (options.recursive && !has) {
       getSubDirectories(dir, function(d) {
-        // watch it only if the filter is not function
-        // or not being skipped explicitly.
-        if (!is.func(options.filter) || options.filter(d, SKIP_FLAG) !== SKIP_FLAG) {
+        if (shouldNotSkip(d, options.filter)) {
           self.watchDirectory(d, options, null, counter);
         }
       }, counter());

--- a/lib/watch.js
+++ b/lib/watch.js
@@ -23,12 +23,10 @@ function unique(arr) {
   });
 }
 
-function flat(arr) {
-  if (is.func(Array.prototype.flat)) {
-    return arr.flat();
-  }
+// One level flat
+function flat1(arr) {
   return arr.reduce(function(acc, v) {
-    return acc.concat(is.array(v) ? flat(v) : v);
+    return acc.concat(v);
   }, []);
 }
 
@@ -252,16 +250,15 @@ Watcher.prototype.close = function(fullPath) {
 }
 
 Watcher.prototype.getWatchedPaths = function(fn) {
-  if (!is.func(fn)) {
-    return false;
-  }
-  var self = this;
-  if (self._isReady) {
-    fn(Object.keys(self.watchers));
-  } else {
-    self.on('ready', function() {
+  if (is.func(fn)) {
+    var self = this;
+    if (self._isReady) {
       fn(Object.keys(self.watchers));
-    });
+    } else {
+      self.on('ready', function() {
+        fn(Object.keys(self.watchers));
+      });
+    }
   }
 }
 
@@ -449,20 +446,17 @@ function composeWatcher(watchers) {
   }
 
   watcher.getWatchedPaths = function(fn) {
-    if (!is.func(fn)) {
-      return false;
-    }
-    var promises = watchers.map(function(w) {
-      return new Promise(function(resolve) {
-        w.getWatchedPaths(function(watched) {
-          resolve(watched);
+    if (is.func(fn)) {
+      var promises = watchers.map(function(w) {
+        return new Promise(function(resolve) {
+          w.getWatchedPaths(resolve);
         });
       });
-    });
-    Promise.all(promises).then(function(result) {
-      var ret = unique(flat(result));
-      fn(ret);
-    });
+      Promise.all(promises).then(function(result) {
+        var ret = unique(flat1(result));
+        fn(ret);
+      });
+    }
   }
 
   return watcher.expose();

--- a/lib/watch.js
+++ b/lib/watch.js
@@ -397,12 +397,9 @@ Watcher.prototype.watchDirectory = function(dir, options, fn, counter = nullCoun
 
     if (options.recursive && !has) {
       getSubDirectories(dir, function(d) {
-        if (is.func(options.filter)) {
-          // Check to see whether to skip this directory.
-          if (options.filter(d, SKIP_FLAG) !== SKIP_FLAG) {
-            self.watchDirectory(d, options, null, counter);
-          }
-        } else {
+        // watch it only if the filter is not function
+        // or not being skipped explicitly.
+        if (!is.func(options.filter) || options.filter(d, SKIP_FLAG) !== SKIP_FLAG) {
           self.watchDirectory(d, options, null, counter);
         }
       }, counter());

--- a/lib/watch.js
+++ b/lib/watch.js
@@ -23,6 +23,15 @@ function unique(arr) {
   });
 }
 
+function flat(arr) {
+  if (is.func(Array.prototype.flat)) {
+    return arr.flat();
+  }
+  return arr.reduce(function(acc, v) {
+    return acc.concat(is.array(v) ? flat(v) : v);
+  }, []);
+}
+
 function assertEncoding(encoding) {
   if (encoding && encoding !== 'buffer' && !Buffer.isEncoding(encoding)) {
     throw new Error('Unknown encoding: ' + encoding);
@@ -243,11 +252,15 @@ Watcher.prototype.close = function(fullPath) {
 }
 
 Watcher.prototype.getWatchedPaths = function(fn) {
-  if (is.func(fn)) {
-    var self = this;
+  if (!is.func(fn)) {
+    return false;
+  }
+  var self = this;
+  if (self._isReady) {
+    fn(Object.keys(self.watchers));
+  } else {
     self.on('ready', function() {
-      var paths = Object.keys(self.watchers);
-      fn(paths);
+      fn(Object.keys(self.watchers));
     });
   }
 }
@@ -413,6 +426,7 @@ function composeWatcher(watchers) {
   var watcher = new Watcher();
   var filterDups = createDupsFilter();
   var counter = watchers.length;
+
   watchers.forEach(function(w) {
     w.on('change', filterDups(function(evt, name) {
       watcher.emit('change', evt, name);
@@ -433,6 +447,24 @@ function composeWatcher(watchers) {
     });
     process.nextTick(emitClose, watcher);
   }
+
+  watcher.getWatchedPaths = function(fn) {
+    if (!is.func(fn)) {
+      return false;
+    }
+    var promises = watchers.map(function(w) {
+      return new Promise(function(resolve) {
+        w.getWatchedPaths(function(watched) {
+          resolve(watched);
+        });
+      });
+    });
+    Promise.all(promises).then(function(result) {
+      var ret = unique(flat(result));
+      fn(ret);
+    });
+  }
+
   return watcher.expose();
 }
 
@@ -443,19 +475,7 @@ function watch(fpath, options, fn) {
     fpath = fpath.toString();
   }
 
-  if (is.array(fpath)) {
-    if (fpath.length === 1) {
-      return watch(fpath[0], options, fn);
-    }
-    var filterDups = createDupsFilter();
-    return composeWatcher(unique(fpath).map(function(f) {
-      var w = watch(f, options);
-      if (fn) w.on('change', filterDups(fn));
-      return w;
-    }));
-  }
-
-  if (!is.exists(fpath)) {
+  if (!is.array(fpath) && !is.exists(fpath)) {
     watcher.emit('error',
       new Error(fpath + ' does not exist.')
     );
@@ -480,6 +500,20 @@ function watch(fpath, options, fn) {
     assertEncoding(options.encoding);
   } else {
     options.encoding = 'utf8';
+  }
+
+  if (is.array(fpath)) {
+    if (fpath.length === 1) {
+      return watch(fpath[0], options, fn);
+    }
+    var filterDups = createDupsFilter();
+    return composeWatcher(unique(fpath).map(function(f) {
+      var w = watch(f, options);
+      if (is.func(fn)) {
+        w.on('change', filterDups(fn));
+      }
+      return w;
+    }));
   }
 
   if (is.file(fpath)) {

--- a/test/test.js
+++ b/test/test.js
@@ -188,13 +188,13 @@ describe('watch for directories', function() {
       delay: 0,
       recursive: true,
       filter: function(filePath, skip) {
-        if (/\/ignored/.test(filePath)) return skip;
+        if (/ignored/.test(filePath)) return skip;
         return true;
       }
     }
 
     watcher = watch(home, options, function(evt, name) {
-      assert.fail("event detect");
+      assert.fail("event detect", name);
     });
 
     watcher.on('ready', function() {

--- a/test/test.js
+++ b/test/test.js
@@ -1,6 +1,7 @@
 var assert = require('assert');
 var Tree = require('./utils/builder');
 var watch = require('../lib/watch');
+var hasNativeRecursive = require('../lib/has-native-recursive');
 
 var tree = Tree();
 var watcher;
@@ -138,7 +139,6 @@ describe('watch for files', function() {
       }, 100);
     });
   });
-
 });
 
 describe('watch for directories', function() {
@@ -473,24 +473,37 @@ describe('options', function() {
       });
     });
 
-    it('should be able to skip subdirectories', function(done) {
+    it('should be able to skip subdirectories with `skip` flag', function(done) {
+      var home = tree.getPath('home');
       var options = {
         delay: 0,
         recursive: true,
         filter: function(name, skip) {
-          if (/deep_node_modules/.test(name)) return skip;
+          if (/\/deep_node_modules/.test(name)) return skip;
         }
       };
-
-      watcher = watch(tree.getPath('home'), options);
+      watcher = watch(home, options);
 
       watcher.getWatchedPaths(function(paths) {
-        var found = paths.find(n => /deep_node_modules/.test(n));
-        assert(!found, 'failed to skip subdirectory');
-        done();
+        hasNativeRecursive(function(supportRecursive) {
+          let watched = supportRecursive
+          // The skip flag has no effect to the platforms which support recursive option,
+          // so the home directory is the only one that's in the watching list.
+          ? [home]
+          // The deep_node_modules and all its subdirectories should not be watched
+          // with skip flag specified in the filter.
+          : tree.getAllDirectories().filter(function(name) {
+              return !/\/deep_node_modules/.test(name);
+            });
+
+          assert.deepStrictEqual(
+            watched.sort(), paths.sort()
+          );
+
+          done();
+        });
       });
     });
-
   });
 
   describe('delay', function() {
@@ -600,51 +613,124 @@ describe('watcher object', function() {
     });
   });
 
-  it('should close a watcher using .close()', function(done) {
-    var dir = tree.getPath('home/a');
-    var file = 'home/a/file1';
-    var times = 0;
-    watcher = watch(dir, { delay: 0 });
-    watcher.on('change', function(evt, name) {
-      times++;
+  describe('close()', function() {
+    it('should close a watcher using .close()', function(done) {
+      var dir = tree.getPath('home/a');
+      var file = 'home/a/file1';
+      var times = 0;
+      watcher = watch(dir, { delay: 0 });
+      watcher.on('change', function(evt, name) {
+        times++;
+      });
+      watcher.on('ready', function() {
+
+        watcher.close();
+
+        tree.modify(file);
+        tree.modify(file, 100);
+
+        setTimeout(function() {
+          assert(watcher.isClosed(), 'watcher should be closed');
+          assert.equal(times, 0, 'failed to close the watcher');
+          done();
+        }, 150);
+      });
     });
-    watcher.on('ready', function() {
 
-      watcher.close();
+    it('Do not emit after close', function(done) {
+      var dir = tree.getPath('home/a');
+      var file = 'home/a/file1';
+      var times = 0;
+      watcher = watch(dir, { delay: 0 });
+      watcher.on('change', function(evt, name) {
+        times++;
+      });
+      watcher.on('ready', function() {
 
-      tree.modify(file);
-      tree.modify(file, 100);
+        watcher.close();
 
-      setTimeout(function() {
-        assert(watcher.isClosed(), 'watcher should be closed');
-        assert.equal(times, 0, 'failed to close the watcher');
-        done();
-      }, 150);
+        var timer = setInterval(function() {
+          tree.modify(file);
+        });
+
+        setTimeout(function() {
+          clearInterval(timer);
+          assert(watcher.isClosed(), 'watcher should be closed');
+          assert.equal(times, 0, 'failed to close the watcher');
+          done();
+        }, 100);
+      });
     });
   });
 
-  it('Do not emit after close', function(done) {
-    var dir = tree.getPath('home/a');
-    var file = 'home/a/file1';
-    var times = 0;
-    watcher = watch(dir, { delay: 0 });
-    watcher.on('change', function(evt, name) {
-      times++;
+  describe('getWatchedPaths()', function() {
+    it('should get all the watched paths', function(done) {
+      var home = tree.getPath('home');
+      watcher = watch(home, {
+        delay: 0,
+        recursive: true
+      });
+      watcher.getWatchedPaths(function(paths) {
+        hasNativeRecursive(function(supportRecursive) {
+          let watched = supportRecursive
+            // The home directory is the only one that's being watched
+            // if the recursive option is natively supported.
+            ? [home]
+            // Otherwise it should include all its subdirectories.
+            : tree.getAllDirectories();
+
+          assert.deepStrictEqual(
+            watched.sort(), paths.sort()
+          );
+
+          done();
+        });
+      });
     });
-    watcher.on('ready', function() {
 
-      watcher.close();
+    it('should get its parent path instead of the file itself', function(done) {
+      var file = tree.getPath('home/a/file1');
+      // The parent path is actually being watched instead.
+      var parent = tree.getPath('home/a');
 
-      var timer = setInterval(function() {
-        tree.modify(file);
+      watcher = watch(file, { delay: 0 });
+
+      watcher.getWatchedPaths(function(paths) {
+        assert.deepStrictEqual([parent], paths);
+        done();
+      });
+    });
+
+    it('should work correctly with composed watcher', function(done) {
+      var a = tree.getPath('home/a');
+
+      var b = tree.getPath('home/b');
+      var file = tree.getPath('home/b/file1');
+
+      var nested = tree.getPath('home/deep_node_modules');
+      var ma = tree.getPath('home/deep_node_modules/ma');
+      var mb = tree.getPath('home/deep_node_modules/mb');
+      var mc = tree.getPath('home/deep_node_modules/mc');
+
+      watcher = watch([a, file, nested], {
+        delay: 0,
+        recursive: true
       });
 
-      setTimeout(function() {
-        clearInterval(timer);
-        assert(watcher.isClosed(), 'watcher should be closed');
-        assert.equal(times, 0, 'failed to close the watcher');
-        done();
-      }, 100);
+      watcher.getWatchedPaths(function(paths) {
+        hasNativeRecursive(function(supportRecursive) {
+          let watched = supportRecursive
+            ? [a, b, nested]
+            : [a, b, nested, ma, mb, mc]
+
+          assert.deepStrictEqual(
+            watched.sort(), paths.sort()
+          );
+
+          done();
+        });
+      });
     });
+
   });
 });

--- a/test/test.js
+++ b/test/test.js
@@ -8,6 +8,7 @@ var watcher;
 
 beforeEach(function() {
   tree = Tree();
+  tree.remove('home/new');
 });
 
 afterEach(function(done) {

--- a/test/test.js
+++ b/test/test.js
@@ -472,6 +472,25 @@ describe('options', function() {
         }, 100);
       });
     });
+
+    it('should be able to skip subdirectories', function(done) {
+      var options = {
+        delay: 0,
+        recursive: true,
+        filter: function(name, skip) {
+          if (/deep_node_modules/.test(name)) return skip;
+        }
+      };
+
+      watcher = watch(tree.getPath('home'), options);
+
+      watcher.getWatchedPaths(function(paths) {
+        var found = paths.find(n => /deep_node_modules/.test(n));
+        assert(!found, 'failed to skip subdirectory');
+        done();
+      });
+    });
+
   });
 
   describe('delay', function() {

--- a/test/test.js
+++ b/test/test.js
@@ -8,7 +8,6 @@ var watcher;
 
 beforeEach(function() {
   tree = Tree();
-  tree.remove('home/new');
 });
 
 afterEach(function(done) {

--- a/test/test.js
+++ b/test/test.js
@@ -486,15 +486,15 @@ describe('options', function() {
 
       watcher.getWatchedPaths(function(paths) {
         hasNativeRecursive(function(supportRecursive) {
-          let watched = supportRecursive
-          // The skip flag has no effect to the platforms which support recursive option,
-          // so the home directory is the only one that's in the watching list.
-          ? [home]
-          // The deep_node_modules and all its subdirectories should not be watched
-          // with skip flag specified in the filter.
-          : tree.getAllDirectories().filter(function(name) {
-              return !/\/deep_node_modules/.test(name);
-            });
+          var watched = supportRecursive
+              // The skip flag has no effect to the platforms which support recursive option,
+              // so the home directory is the only one that's in the watching list.
+            ? [home]
+              // The deep_node_modules and all its subdirectories should not be watched
+              // with skip flag specified in the filter.
+            : tree.getAllDirectories().filter(function(name) {
+                return !/\/deep_node_modules/.test(name);
+              });
 
           assert.deepStrictEqual(
             watched.sort(), paths.sort()
@@ -672,11 +672,11 @@ describe('watcher object', function() {
       });
       watcher.getWatchedPaths(function(paths) {
         hasNativeRecursive(function(supportRecursive) {
-          let watched = supportRecursive
-            // The home directory is the only one that's being watched
-            // if the recursive option is natively supported.
+          var watched = supportRecursive
+              // The home directory is the only one that's being watched
+              // if the recursive option is natively supported.
             ? [home]
-            // Otherwise it should include all its subdirectories.
+              // Otherwise it should include all its subdirectories.
             : tree.getAllDirectories();
 
           assert.deepStrictEqual(
@@ -719,9 +719,9 @@ describe('watcher object', function() {
 
       watcher.getWatchedPaths(function(paths) {
         hasNativeRecursive(function(supportRecursive) {
-          let watched = supportRecursive
+          var watched = supportRecursive
             ? [a, b, nested]
-            : [a, b, nested, ma, mb, mc]
+            : [a, b, nested, ma, mb, mc];
 
           assert.deepStrictEqual(
             watched.sort(), paths.sort()
@@ -731,6 +731,5 @@ describe('watcher object', function() {
         });
       });
     });
-
   });
 });

--- a/test/test.js
+++ b/test/test.js
@@ -182,6 +182,28 @@ describe('watch for directories', function() {
     });
   });
 
+  it('should not watch new created directories which are being skipped in the filter', function(done) {
+    var home = tree.getPath('home');
+    var options = {
+      delay: 0,
+      recursive: true,
+      filter: function(filePath, skip) {
+        if (/\/ignored/.test(filePath)) return skip;
+        return true;
+      }
+    }
+
+    watcher = watch(home, options, function(evt, name) {
+      assert.fail("event detect");
+    });
+
+    watcher.on('ready', function() {
+      tree.newFile('home/ignored/file');
+      tree.modify('home/ignored/file', 100);
+      setTimeout(done, 150);
+    });
+  });
+
   it('should keep watching after removal of sub directory', function(done) {
     var home = tree.getPath('home');
     var file1 = tree.getPath('home/e/file1');

--- a/test/utils/builder.js
+++ b/test/utils/builder.js
@@ -58,10 +58,12 @@ var defaultTestPath= path.join(__dirname, '__TREE__');
 
 module.exports = function builder() {
   var root = defaultTestPath;
+  var allDirectories = [];
   transformed.forEach(function(line) {
     var target = path.join(root, line.text)
     if (line.type === 'dir') {
       fs.ensureDirSync(target);
+      allDirectories.push(target);
     }
     else {
       fs.ensureFileSync(target);
@@ -117,6 +119,9 @@ module.exports = function builder() {
       } catch (e) {
         console.warn('cleanup failed.');
       }
+    },
+    getAllDirectories: function() {
+      return allDirectories;
     }
   }
 }

--- a/test/utils/builder.js
+++ b/test/utils/builder.js
@@ -121,9 +121,9 @@ module.exports = function builder() {
     },
     getAllDirectories: function() {
       function walk(dir) {
-        let ret = [];
+        var ret = [];
         fs.readdirSync(dir).forEach(function(d) {
-          let fpath = path.join(dir, d);
+          var fpath = path.join(dir, d);
           if (fs.statSync(fpath).isDirectory()) {
             ret.push(fpath);
             ret = ret.concat(walk(fpath));

--- a/test/utils/builder.js
+++ b/test/utils/builder.js
@@ -56,11 +56,24 @@ function transform(arr) {
 
 var transformed= transform(code);
 var defaultTestPath= path.join(__dirname, '__TREE__');
-var timers = [];
+
+var delayTimers = [];
+
+function maybeDelay(fn, delay) {
+  if (delay) {
+    delayTimers.push(setTimeout(fn, delay));
+  } else {
+    fn();
+  }
+}
+
+function clearDelayTimers() {
+  delayTimers.forEach(clearTimeout);
+  delayTimers.length = 0;
+}
 
 module.exports = function builder() {
-  timers.forEach(clearTimeout);
-  timers = [];
+  clearDelayTimers();
 
   var root = defaultTestPath;
   transformed.forEach(function(line) {
@@ -78,21 +91,21 @@ module.exports = function builder() {
     },
     modify: function(fpath, delay) {
       var filePath = this.getPath(fpath);
-      timers.push(setTimeout(function() {
+      maybeDelay(function() {
         fs.appendFileSync(filePath, 'hello');
-      }, delay || 0));
+      }, delay);
     },
     remove: function(fpath, delay) {
       var filePath = this.getPath(fpath);
-      timers.push(setTimeout(function() {
+      maybeDelay(function() {
         fs.removeSync(filePath);
-      }, delay || 0));
+      }, delay);
     },
     newFile: function(fpath, delay) {
       var filePath = this.getPath(fpath);
-      timers.push(setTimeout(function() {
+      maybeDelay(function() {
         fs.ensureFileSync(filePath);
-      }, delay || 0));
+      }, delay);
     },
     newRandomFiles: function(fpath, count) {
       var names = [];
@@ -112,9 +125,9 @@ module.exports = function builder() {
     },
     newDir: function(fpath, delay) {
       var filePath = this.getPath(fpath);
-      setTimeout(function() {
+      maybeDelay(function() {
         fs.ensureDirSync(filePath);
-      }, delay || 0);
+      }, delay);
     },
     cleanup: function() {
       try {

--- a/test/utils/builder.js
+++ b/test/utils/builder.js
@@ -1,5 +1,6 @@
 var fs = require('fs-extra');
 var path = require('path');
+
 var structure = fs.readFileSync(
   path.join(__dirname, './structure'),
   'utf-8'
@@ -58,12 +59,10 @@ var defaultTestPath= path.join(__dirname, '__TREE__');
 
 module.exports = function builder() {
   var root = defaultTestPath;
-  var allDirectories = [];
   transformed.forEach(function(line) {
     var target = path.join(root, line.text)
     if (line.type === 'dir') {
       fs.ensureDirSync(target);
-      allDirectories.push(target);
     }
     else {
       fs.ensureFileSync(target);
@@ -121,7 +120,18 @@ module.exports = function builder() {
       }
     },
     getAllDirectories: function() {
-      return allDirectories;
+      function walk(dir) {
+        let ret = [];
+        fs.readdirSync(dir).forEach(function(d) {
+          let fpath = path.join(dir, d);
+          if (fs.statSync(fpath).isDirectory()) {
+            ret.push(fpath);
+            ret = ret.concat(walk(fpath));
+          }
+        });
+        return ret;
+      }
+      return walk(root);
     }
   }
 }

--- a/test/utils/builder.js
+++ b/test/utils/builder.js
@@ -56,8 +56,12 @@ function transform(arr) {
 
 var transformed= transform(code);
 var defaultTestPath= path.join(__dirname, '__TREE__');
+var timers = [];
 
 module.exports = function builder() {
+  timers.forEach(clearTimeout);
+  timers = [];
+
   var root = defaultTestPath;
   transformed.forEach(function(line) {
     var target = path.join(root, line.text)
@@ -74,21 +78,21 @@ module.exports = function builder() {
     },
     modify: function(fpath, delay) {
       var filePath = this.getPath(fpath);
-      setTimeout(function() {
+      timers.push(setTimeout(function() {
         fs.appendFileSync(filePath, 'hello');
-      }, delay || 0);
+      }, delay || 0));
     },
     remove: function(fpath, delay) {
       var filePath = this.getPath(fpath);
-      setTimeout(function() {
+      timers.push(setTimeout(function() {
         fs.removeSync(filePath);
-      }, delay || 0);
+      }, delay || 0));
     },
     newFile: function(fpath, delay) {
       var filePath = this.getPath(fpath);
-      setTimeout(function() {
+      timers.push(setTimeout(function() {
         fs.ensureFileSync(filePath);
-      }, delay || 0)
+      }, delay || 0));
     },
     newRandomFiles: function(fpath, count) {
       var names = [];


### PR DESCRIPTION
This is an attempt to fix #93 by introducing a third return value. For example:

```js
let options = {
  recursive: true,
  // watch all js files and skip node_modules
  filter(name) {
    if (/node_modules/.test(name)) {
      // skip to watch all the the sub-directories if it's on Linux
      return 'skip';
    }
    if (/\.js$/.test(name)) {
      // as before
      return true;
    }
  }
}

watch('./', options, console.log);
```

I couldn't find a way to write a test at this moment


--------------------------
## update
Now this is how to ignore and skip to watch the `node_modules` directory.
```js
let options = {
  recursive: true,
  filter(name, skip) {
    if (/\/node_modules/.test(name)) return skip;
    return true;
  }
}

watch('./', options, console.log)
```

In order to test it I've also added a new method to get all the watched paths.

```js
let watcher = watch('./', options, console.log);

watcher.getWatchedPaths(function(paths) {

});
```