### PR TITLE
fix Callback type

### DIFF
--- a/lib/watch.d.ts
+++ b/lib/watch.d.ts
@@ -22,7 +22,7 @@ declare function watch(pathName: PathName, callback: Callback): Watcher;
 declare function watch(pathName: PathName, options: Options, callback: Callback): Watcher;
 
 type EventType = 'update' | 'remove';
-type Callback = (eventType ?: EventType, filePath ?: string) => any;
+type Callback = (eventType: EventType, filePath: string) => any;
 type PathName = string | Array<string>;
 type FilterReturn = boolean | symbol;
 


### PR DESCRIPTION
To let user of this library omit an argument in a callback function, we do not need to make the argument type optional.

On the other hand, making an argument type optional, will force the user handle the case where `eventType` or `filePath` is `undefined` (which will not happen.)