### PR TITLE
skip: only provide on initial recurse

### DIFF
--- a/lib/watch.js
+++ b/lib/watch.js
@@ -37,17 +37,16 @@ function assertEncoding(encoding) {
 }
 
 function guard(fn) {
-  return function(arg, action) {
-    if (is.func(fn)) {
-      var ret = fn(arg, SKIP_FLAG);
-      if (ret && ret !== SKIP_FLAG) action();
+  if (is.func(fn))
+    return function(arg, action) {
+      if (fn(arg, false)) action();
     }
-    else if (is.regExp(fn)) {
+  if (is.regExp(fn))
+    return function(arg, action) {
       if (fn.test(arg)) action();
     }
-    else {
+  return function(arg, action) {
       action();
-    }
   }
 }
 


### PR DESCRIPTION
`skip` is truthy when checking if a directory should be recursively watched, and `false` otherwise.

This allows running different checks.

Fixes #117 