### PR TITLE
Fix can't listener error event on incorrect file/directory

### DIFF
--- a/lib/watch.js
+++ b/lib/watch.js
@@ -471,9 +471,11 @@ function watch(fpath, options, fn) {
   }
 
   if (!is.array(fpath) && !is.exists(fpath)) {
-    watcher.emit('error',
-      new Error(fpath + ' does not exist.')
-    );
+    process.nextTick(function() {
+      watcher.emit('error',
+        new Error(fpath + ' does not exist.')
+      );
+    });
   }
 
   if (is.string(options)) {

--- a/test/test.js
+++ b/test/test.js
@@ -585,11 +585,12 @@ describe('options', function() {
 describe('parameters', function() {
   it('should throw error on non-existed file', function(done) {
     var somedir = tree.getPath('home/somedir');
-    try {
-      watcher = watch(somedir);
-    } catch(err) {
-      done();
-    }
+    watcher = watch(somedir);
+    watcher.on('error', function(err) {
+      if (err.message.includes('does not exist')) {
+        done()
+      }
+    })
   });
 
   it('should accept filename as Buffer', function(done) {


### PR DESCRIPTION
Fix can't listener error event on incorrect file/directory.

Like this:
```js
const watcher = watch('incorrect-some-file-path', function(evt, name) {
  //do something
});
watcher.on('error', () => {
  //do something
});
```

expose error:
```bash
events.js:353
      throw er; // Unhandled 'error' event
```
