### PR TITLE
Catch fs.watch exceptions

### DIFF
--- a/lib/watch.js
+++ b/lib/watch.js
@@ -126,6 +126,16 @@ function createDupsFilter() {
   }
 }
 
+function tryWatch(watcher, dir, opts) {
+  try {
+    return fs.watch(dir, opts);
+  } catch (e) {
+    process.nextTick(function() {
+      watcher.emit('error', e);
+    });
+  }
+}
+
 function getSubDirectories(dir, fn, done = function() {}) {
   if (is.directory(dir)) {
     fs.readdir(dir, function(err, all) {
@@ -357,7 +367,11 @@ Watcher.prototype.watchFile = function(file, options, fn) {
   // no need to watch recursively
   delete opts.recursive;
 
-  var watcher = fs.watch(parent, opts);
+  var watcher = tryWatch(this, parent, opts);
+  if (!watcher) {
+    return;
+  }
+
   this.add(watcher, {
     type: 'file',
     fpath: parent,
@@ -395,7 +409,11 @@ Watcher.prototype.watchDirectory = function(dir, options, fn, counter = nullCoun
       return self.close();
     }
 
-    var watcher = fs.watch(dir, opts);
+    var watcher = tryWatch(self, dir, opts);
+    if (!watcher) {
+      done();
+      return;
+    }
 
     self.add(watcher, {
       type: 'dir',

--- a/test/test.js
+++ b/test/test.js
@@ -176,6 +176,20 @@ describe('watch for files', function() {
       }, 100);
     });
   });
+
+  it('should error when parent gets deleted before calling fs.watch', function(done) {
+    var fpath = tree.getPath('home/a/file1');
+    watcher = watch(fpath, Object.defineProperty({}, 'test', {
+      enumerable: true,
+      get: function() {
+        tree.remove('home/a');
+        return 'test';
+      }
+    }));
+    watcher.on('error', function() {
+      done();
+    });
+  });
 });
 
 describe('watch for directories', function() {
@@ -280,6 +294,21 @@ describe('watch for directories', function() {
         assert.deepStrictEqual(events, ['update']);
         done();
       }, 350);
+    });
+  });
+
+  it('should error when directory gets deleted before calling fs.watch', function(done) {
+    var dir = 'home/c';
+    var fpath = tree.getPath(dir);
+    watcher = watch(fpath, Object.defineProperty({}, 'test', {
+      enumerable: true,
+      get: function() {
+        tree.remove(dir);
+        return 'test';
+      }
+    }));
+    watcher.on('error', function() {
+      done();
     });
   });
 });


### PR DESCRIPTION
- Files / directories might get deleted between `is.directory` / `is.file` / `fs.readdir` and the actual `fs.watch` call.
- electron monkey patches the `fs` API to transparently support files contained in `asar` archives but `fs.watch` does not work for them. (See https://github.com/FredrikNoren/ungit/issues/1523)

To test this I relied on the fact the the options are getting copied with `Object.assign({}, options, {...})` so that I could delete the directory before `fs.watch` is called but after the `is.directory` / `is.file` checks.

Fixes https://github.com/yuanchuan/node-watch/issues/108