### PR TITLE
fix: add export to interface for Watcher

### DIFF
--- a/lib/watch.d.ts
+++ b/lib/watch.d.ts
@@ -60,7 +60,7 @@ type Options = {
   delay ?: number;
 };
 
-declare interface Watcher extends FSWatcher {
+export declare interface Watcher extends FSWatcher {
   /**
    * Returns `true` if the watcher has been closed.
    */


### PR DESCRIPTION
A simple code like this in ts project:
```
import watch from "node-watch";

export const MyWatcher = function(){
  return watch("src")
}
```

generate this type error:
`Exported variable 'MyWatcher' has or is using name 'Watcher' from external module "/Users/me/Documents/me-project/node_modules/node-watch/lib/watch" but cannot be named.`

I try to fix it